### PR TITLE
fix: change docs resource link to the new site

### DIFF
--- a/contents/faq.mdx
+++ b/contents/faq.mdx
@@ -6,7 +6,7 @@ Halaman ini berisi pertanyaan yang sering ditanyakan pada grup Telegram kami. In
 
 ### Saya masih _newbie_. Boleh minta e-book untuk belajar React? Adakah tutorial React berbahasa Indonesia?
 
-- Kami menyarankan untuk membaca dokumentasi resmi React yang bisa kalian temui [di situs resmi React](https://reactjs.org/).
+- Kami menyarankan untuk membaca dokumentasi resmi React yang bisa kalian temui [di situs resmi React](https://react.dev/).
 - Jika kalian merasa dokumentasi React masih belum memadai, atau kalian tipe yang lebih ingin belajar melalui video, maka Anda bisa menonton video mas **prawito hudoro** yang bisa kalian tonton di [channel YouTube-nya](https://www.youtube.com/watch?v=5kHyviqjhCk&list=PLU4DS8KR-LJ03qEsHn9zV4qdhcWtusBqb).
 
 ### JavaScript dulu atau React dulu?

--- a/resources/learnings.json
+++ b/resources/learnings.json
@@ -8,7 +8,7 @@
   {
     "type": "Dokumentasi",
     "title": "Dokumentasi React (ID)",
-    "description": "Dokumentasi React juga tersedia dalam Bahasa Indonesia. Anda juga dapat berkontribusi menerjemahkan dokumentasi React melalui GitHub reactjs/id.reactjs.org.",
+    "description": "Dokumentasi React juga tersedia dalam Bahasa Indonesia. Anda juga dapat berkontribusi menerjemahkan dokumentasi React melalui GitHub reactjs/id.react.dev.",
     "url": "https://id.react.dev",
     "featured": true
   },

--- a/resources/learnings.json
+++ b/resources/learnings.json
@@ -3,13 +3,13 @@
     "type": "Dokumentasi",
     "title": "Dokumentasi React (EN)",
     "description": "Dokumentasi React merupakan sumber daya React terlengkap. Anda dapat menemukan segalanya, mulai dari referensi API, tutorial praktis cara mengaplikasikan React pada sebuah aplikasi, hingga update terbaru mengenai React.",
-    "url": "https://reactjs.org"
+    "url": "https://react.dev"
   },
   {
     "type": "Dokumentasi",
     "title": "Dokumentasi React (ID)",
     "description": "Dokumentasi React juga tersedia dalam Bahasa Indonesia. Anda juga dapat berkontribusi menerjemahkan dokumentasi React melalui GitHub reactjs/id.reactjs.org.",
-    "url": "https://id.reactjs.org",
+    "url": "https://id.react.dev",
     "featured": true
   },
   {


### PR DESCRIPTION
React has officially moved its documentation site to:

- EN: https://react.dev/
- ID: https://id.react.dev/

This PR is intended to change the documentation redirect into the new one